### PR TITLE
Reconfigures the project to be deployed to Jellyfin's webserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.zed

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,13 +7,15 @@ import { getUserLibraryApi } from '@jellyfin/sdk/lib/utils/api/user-library-api'
 import { BaseItemKind, ItemFields } from '@jellyfin/sdk/lib/generated-client/models';
 
 // 1. Initialize SDK
+const credentials = JSON.parse(localStorage.getItem("jellyfin_credentials"))["Servers"][0]
+
 const jellyfin = new Jellyfin({
     clientInfo: { name: 'JellyTags', version: '1.0.0' },
-    deviceInfo: { name: 'Browser', id: 'browser-uuid' }
+    deviceInfo: { name: 'Browser', id: credentials["Id"] }
 });
 
-const serverUrl = import.meta.env.VITE_JELLYFIN_URL;
-const token = import.meta.env.VITE_JELLYFIN_TOKEN;
+const serverUrl = credentials["ManualAddress"]
+const token = credentials["AccessToken"]
 
 const api = jellyfin.createApi(serverUrl);
 api.accessToken = token;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,10 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  base: "", // dynamic path for hosting
   server: {
     host: '0.0.0.0',
     port: 8181
-  },
-  define: {
-    'import.meta.env.VITE_JELLYFIN_URL': '"__JELLYFIN_URL__"',
-    'import.meta.env.VITE_JELLYFIN_TOKEN': '"__JELLYFIN_TOKEN__"',
   },
   build: {
     modulePreload: false,


### PR DESCRIPTION
I think distributing this project as a separate docker container or server is going to run into a lot of annoying problems with CORS:

<img width="373" height="74" alt="image" src="https://github.com/user-attachments/assets/001dd7b6-e1e5-4fff-8ef8-fdefc12cc1b8" />

It is technically solvable in a variety of ways, but I think the simplest approach is to host from within the webserver that jellyfin is already running itself. By copying the dist files into `jellyfin-web/jellytags` directory of the jellyfin server, you can access the page via `http://your-jellyfin-server.example.com/web/jellytags`. This addresses the CORS issue because the javascript is hosted from the same origin as the API it's accessing, therefore no cross-origin requests.

Another cool advantage of doing things this way is that we can fetch the logged in user's server URL and access token out of localStorage, meaning we don't even have to customize the build with environment variables anymore. This means that a static build can be deployed without needing a substitution script.

Seeing as how this is a pretty significant change to how the project works, I only implemented this little proof of concept before submitting a draft PR, since I didn't want to go any further in case you have another solution in mind.

I don't use docker for my jellyfin server, but I think for people who do, they could use an [image source for a volume mount](https://docs.docker.com/reference/compose-file/services/#long-syntax-6) in their docker-compose.yml. Everyone else can simply unzip an archive into the jellyfin-web directory on their jellyfin server.

If we do want to keep going in this direction, here's what's still left to be done:

- [ ] Detect when the user is not logged in and give them a helpful message instead of crashing
- [ ] Provide releases as a zip archive
- [ ] Update Dockerfile
- [ ] Update documentation about how to deploy