### PR TITLE
fix: load library from an administrator user (#10)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,10 @@ async function init() {
             throw new Error("No users found. Ensure your API Token has admin permissions.");
         }
 
-        currentUserId = usersRes.data[0].Id as string;
+        // Prefer an administrator account. The first user returned by the API may
+        // be a restricted account whose limited library access would hide most items.
+        const adminUser = usersRes.data.find(u => u.Policy?.IsAdministrator);
+        currentUserId = (adminUser || usersRes.data[0]).Id as string;
 
         await fetchItems();
     } catch (e) {


### PR DESCRIPTION
## Problem

`init()` picked `usersRes.data[0]` as the user whose library to load. The first user returned by `/Users` is not necessarily an administrator — if that account has restricted library access, JellyTags only renders the items visible to that account (reports of ~12 items out of thousands), even though the API token belongs to an admin.

## Fix

Select the first user whose `Policy.IsAdministrator` is true, falling back to the first user when none is flagged:

```ts
const adminUser = usersRes.data.find(u => u.Policy?.IsAdministrator);
currentUserId = (adminUser || usersRes.data[0]).Id as string;
```

No new configuration required. Verified against a live server: the full library now loads.

Fixes #10