### PR TITLE
fix: tag updates fail on items with trickplay (#2)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -523,10 +523,15 @@ function renderSidebarEditor(tagCounts: Record<string, number>) {
                             ? currentTags.filter((tag: string) => !proposedTags.includes(tag))
                             : [...proposedTags];
 
+                    // Jellyfin rejects the round-tripped DTO when it carries a
+                    // Trickplay map: TrickplayInfoDto fails to deserialize on the
+                    // server and the whole update fails. Strip it before sending.
+                    const { Trickplay: _trickplay, ...sanitizedItem } = serverItem;
+
                     await updateApi.updateItem({
                         itemId: id,
                         baseItemDto: {
-                            ...serverItem,
+                            ...sanitizedItem,
                             Id: id,
                             Name: itemName,
                             Tags: updatedTags,


### PR DESCRIPTION
## Problem

Applying tags returned `Error updating tags.` for some items. The Jellyfin server log shows:

```
System.InvalidOperationException: Each parameter in the deserialization constructor on type
'MediaBrowser.Model.Dto.TrickplayInfoDto' must bind to an object property or field on deserialization.
```

The update flow fetches the item via `/Items` and spreads the whole DTO back into the `updateItem` POST body. That DTO includes a `Trickplay` map, and `TrickplayInfoDto` cannot be deserialized by the server on write — so items that had trickplay images generated failed, while others succeeded. This matches the "happens on some items, not all" reports.

## Fix

Strip `Trickplay` from the payload before posting:

```ts
const { Trickplay: _trickplay, ...sanitizedItem } = serverItem;
await updateApi.updateItem({ itemId: id, baseItemDto: { ...sanitizedItem, /* … */ } });
```

Verified against a live server that add/remove/replace still persist correctly (confirmed in Jellyfin).

Fixes #2