### PR TITLE
fix: make 'npm run dev' usable with .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "temp",
+  "name": "jellytags",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from 'vite'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   server: {
     host: '0.0.0.0',
     port: 8181
   },
-  define: {
-    'import.meta.env.VITE_JELLYFIN_URL': '"__JELLYFIN_URL__"',
-    'import.meta.env.VITE_JELLYFIN_TOKEN': '"__JELLYFIN_TOKEN__"',
-  },
+  // For production builds the values are baked as placeholders and swapped in at
+  // container start by docker-entrypoint.sh. In dev we let Vite load the real
+  // values from .env so `npm run dev` can actually connect to Jellyfin.
+  ...(command === 'build' ? {
+    define: {
+      'import.meta.env.VITE_JELLYFIN_URL': '"__JELLYFIN_URL__"',
+      'import.meta.env.VITE_JELLYFIN_TOKEN': '"__JELLYFIN_TOKEN__"',
+    },
+  } : {}),
   build: {
     modulePreload: false,
     rollupOptions: {
@@ -19,4 +24,4 @@ export default defineConfig({
       }
     }
   }
-})
+}))


### PR DESCRIPTION
## Problem

`vite.config.ts` set:

```ts
define: {
  'import.meta.env.VITE_JELLYFIN_URL': '"__JELLYFIN_URL__"',
  'import.meta.env.VITE_JELLYFIN_TOKEN': '"__JELLYFIN_TOKEN__"',
}
```

unconditionally. `define` applies in **both** `vite` (dev) and `vite build`, so it overrode the values Vite normally loads from `.env`. Following the README's *Installation (Local Development)* steps — create `.env`, `npm run dev` — always resulted in **Connection Failed**, because the app received the literal `__JELLYFIN_URL__` / `__JELLYFIN_TOKEN__` placeholders instead of the configured server.

## Fix

Scope the placeholder `define` to `command === 'build'`. The Docker flow is unchanged — `vite build` still bakes the placeholders and `docker-entrypoint.sh` substitutes the real values at container start (verified: the built `dist/assets/index.js` still contains `__JELLYFIN_URL__`). In dev, Vite's standard `.env` loading now works, so `npm run dev` connects.

Also renames the package from the scaffold default `temp` to `jellytags`.

Verified locally: `npm run dev` with a `.env` connects to Jellyfin and loads the library.