### PR TITLE
fix: mobile header layout, collapsible filters, and a footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,19 @@
         </div>
       </div>
     </div>
+
+    <footer class="app-footer">
+      <span class="app-footer-text">JellyTags &middot; Batch tag editor for Jellyfin</span>
+      <nav class="app-footer-links">
+        <a href="https://github.com/christt105/jellytags" target="_blank" rel="noopener noreferrer">
+          <svg class="app-footer-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+            <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+          </svg>
+          GitHub
+        </a>
+        <a href="https://ko-fi.com/christt105" target="_blank" rel="noopener noreferrer">Ko-fi</a>
+      </nav>
+    </footer>
   </div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
         <div class="header-search header-search-wrapper">
           <input id="search-input" class="glass-input search-input-field" placeholder="Search by name or tag..." />
         </div>
+        <button id="filters-toggle" class="glass-button header-button mobile-only" style="display: none;">
+          Filters
+        </button>
+        <button id="sidebar-toggle" class="glass-button header-button mobile-only" style="display: none;">
+          ☰
+        </button>
       </div>
 
       <div class="header-actions">
@@ -42,9 +48,6 @@
         </button>
         <button id="refresh-btn" class="glass-button header-button">
           Refresh
-        </button>
-        <button id="sidebar-toggle" class="glass-button header-button mobile-only" style="display: none;">
-          ☰
         </button>
       </div>
     </header>

--- a/src/index.css
+++ b/src/index.css
@@ -202,6 +202,42 @@ select.glass-input option {
   box-shadow: none;
 }
 
+/* Footer */
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  padding: 12px 24px;
+  margin: 0 16px 12px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.app-footer-links {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.app-footer a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.app-footer a:hover {
+  color: var(--jelly-blue);
+}
+
+.app-footer-icon {
+  display: block;
+}
+
 /* Main Content */
 .main-layout {
   display: flex;
@@ -599,6 +635,11 @@ select.glass-input option {
 
   #filters-toggle.active {
     background: linear-gradient(135deg, var(--jelly-blue), var(--jelly-purple));
+  }
+
+  .app-footer {
+    justify-content: center;
+    text-align: center;
   }
 
   .main-content {

--- a/src/index.css
+++ b/src/index.css
@@ -579,6 +579,28 @@ select.glass-input option {
     display: inline-block !important;
   }
 
+  /* Collapsed by default to free up vertical space; the Filters button toggles
+     .show. When open the controls wrap into a tidy grid instead of overflowing. */
+  .header-actions {
+    display: none;
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .header-actions.show {
+    display: flex;
+  }
+
+  .header-actions > * {
+    flex: 1 1 calc(50% - 5px);
+    min-width: 0 !important;
+  }
+
+  #filters-toggle.active {
+    background: linear-gradient(135deg, var(--jelly-blue), var(--jelly-purple));
+  }
+
   .main-content {
     width: 100%;
   }
@@ -587,17 +609,18 @@ select.glass-input option {
     position: fixed !important;
     top: 0;
     right: 0 !important;
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     padding: 0 !important;
     z-index: 100;
     pointer-events: none;
+    overflow: hidden;
   }
 
   #tag-editor-sidebar {
-    width: 100vw !important;
+    width: 100% !important;
     height: 100vh !important;
-    max-width: 100vw;
+    max-width: 100%;
     border-radius: 0;
     border: none;
     margin: 0;
@@ -617,7 +640,7 @@ select.glass-input option {
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
+    width: 100%;
     height: 100vh;
     background: rgba(0, 0, 0, 0.3);
     z-index: 99;

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,15 @@ sidebarToggle?.addEventListener('click', openSidebar);
 sidebarClose?.addEventListener('click', closeSidebar);
 sidebarOverlay?.addEventListener('click', closeSidebar);
 
+// On narrow screens the filter and sort controls are collapsed by default to
+// free up vertical space; this button reveals them.
+const filtersToggle = document.getElementById('filters-toggle');
+const headerActions = document.querySelector('.header-actions');
+filtersToggle?.addEventListener('click', () => {
+    headerActions?.classList.toggle('show');
+    filtersToggle.classList.toggle('active');
+});
+
 // 3. Core Logic
 async function init() {
     try {


### PR DESCRIPTION
## Problems

On phones the page had horizontal scroll, the header controls were pushed off the right edge, and the filter row took up roughly half the screen height.

- `.header-actions` was a non-wrapping flex row, and the two selects carried `min-width: 180px` / `170px`. Their combined width exceeds a phone screen, so with the header's `justify-content: space-between` they overflowed to the right.
- The fixed mobile sidebar, its container, and the overlay used `100vw`, which is wider than the visual viewport by the scrollbar width and adds horizontal overflow (the closed sidebar sits at `translateX(100%)`).
- All the filter and sort controls were always visible, consuming vertical space on small screens.

## Changes

Inside the `max-width: 768px` breakpoint (desktop layout is untouched unless noted):

- `.header-actions` now wraps into a two-column grid (`flex-wrap: wrap`, each control `flex: 1 1 calc(50% - 5px)` with `min-width: 0`) instead of overflowing.
- The sidebar container, sidebar, and overlay use `100%` instead of `100vw`, and the fixed container gets `overflow: hidden` so the off-screen sidebar cannot create horizontal scroll.
- The controls are collapsed by default behind a new **Filters** toggle button, so the grid is visible immediately. The tag-editor (`☰`) button was moved out of that row into the title area so it stays reachable while the filters are collapsed.

Also adds a small site footer below the main layout (on all viewports) showing the project name and links to the GitHub repository and Ko-fi, centered on small screens.

Best reviewed and tested on a real phone.