### PR TITLE
fix: clarify existing-tag staging in the editor sidebar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -538,6 +538,22 @@ select.glass-input option {
   border-radius: 4px;
   cursor: pointer;
   border: 1px solid transparent;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.existing-tag:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.existing-tag.staged {
+  background: rgba(170, 92, 195, 0.25);
+  color: #e5b3fe;
+  border-color: rgba(170, 92, 195, 0.6);
+}
+
+.existing-tag.staged .existing-tag-count {
+  opacity: 0.7;
 }
 
 .existing-tag-count {

--- a/src/main.ts
+++ b/src/main.ts
@@ -417,13 +417,17 @@ function renderSidebarEditor(valueCounts: Record<string, number>) {
                 <div class="existing-tags-section">
                     <h4 class="existing-tags-title">Existing ${editTarget} in Selection:</h4>
                     <div class="existing-tags-list">
-                        ${Object.entries(valueCounts).map(([t, count]) => `
-                            <span data-add-tag="${escapeHtml(t)}" title="Present on ${count} item(s)" class="existing-tag">
+                        ${Object.entries(valueCounts).map(([t, count]) => {
+        const isStaged = proposed.includes(t);
+        const hint = isStaged ? 'Staged — click to unstage' : `Present on ${count} item(s) — click to stage`;
+        return `
+                            <span data-add-tag="${escapeHtml(t)}" title="${hint}" class="existing-tag${isStaged ? ' staged' : ''}">
                                 ${escapeHtml(t)} <span class="existing-tag-count">(${count})</span>
                             </span>
-                        `).join('')}
+                        `;
+    }).join('')}
                     </div>
-                    <p class="existing-tag-hint">Click to add to all</p>
+                    <p class="existing-tag-hint">Click a tag to stage it for all selected items, then Apply. Click again to unstage.</p>
                 </div>
             ` : ''}
         </div>
@@ -513,10 +517,10 @@ function renderSidebarEditor(valueCounts: Record<string, number>) {
         el.addEventListener('click', (e) => {
             const value = (e.currentTarget as HTMLElement).getAttribute('data-add-tag')!;
             const proposed = getProposed();
-            if (!proposed.includes(value)) {
-                proposed.push(value);
-                renderSidebarEditor(valueCounts);
-            }
+            const idx = proposed.indexOf(value);
+            if (idx === -1) proposed.push(value);
+            else proposed.splice(idx, 1);
+            renderSidebarEditor(valueCounts);
         });
     });
 


### PR DESCRIPTION
Closes #17

### Problem
In the editor sidebar, the "Existing Tags in Selection" chips already staged a tag into the "Tags to Apply" list, but:

- the static hint "Click to add to all" read like a single button, not a label for the chips above it, and
- clicking a chip gave no visual feedback, so it looked like nothing happened.

That is the confusion reported in #17.

### Changes
- Existing-tag chips now **toggle**: click to stage, click again to unstage (previously a second click did nothing).
- Staged chips are **highlighted** (purple, matching the "Tags to Apply" chips) with a hover state, so the click is visible.
- Each chip has a tooltip ("Present on N item(s)" / "Staged, click to unstage").
- Reworded the hint to "Click a tag to stage it for all selected items, then Apply. Click again to unstage." so it points at the chips and explains the toggle.

This also covers the reporter goal of selecting existing tags to remove them: stage the tags, switch to Remove mode, Apply.

### Notes
Tags and Genres share this editor, so the behavior applies to both. No change to the apply/update pipeline.
