### PR TITLE
feat: publish PR preview images to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,34 +4,53 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   push_to_registry:
     name: Build & Push Docker image
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6.0.2
-      
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.0.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6.0.0
         with:
-          images: ${{ secrets.DOCKER_USERNAME }}/jellytags
+          images: |
+            name=ghcr.io/${{ github.repository }}
+            name=docker.io/${{ secrets.DOCKER_USERNAME }}/jellytags,enable=${{ github.event_name != 'pull_request' }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
-            
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
-            
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+            type=ref,event=pr
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7.0.0
         with:


### PR DESCRIPTION
## Summary
- On every PR against `main`, build and push a Docker image tagged `pr-<n>` to `ghcr.io/christt105/jellytags`.
- Docker Hub login/push stays limited to tagged releases; PR builds only touch GHCR via `GITHUB_TOKEN`.
- Guarded against running with secrets on PRs from forks (`head.repo.full_name == github.repository`).

## Test plan
- [x] Confirm the workflow run succeeds on this PR
- [x] Confirm image `ghcr.io/christt105/jellytags:pr-<this PR number>` is published
- [x] Check GHCR package visibility (may default to private, needs to be public to `docker pull` without auth)