### PR TITLE
feat: filter media grid by missing or present tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ JellyTags is a lightweight, responsive web application for managing tags within 
 - **Tag Suggestions:** View existing tags across your selection and easily propose new or current ones.
 - **Responsive Design:** A mobile-friendly sliding sidebar allows you to manage tags on the go.
 - **Sorting & Filtering:** Find specific media quickly using the built-in search bar and sorting dropdown.
+- **Tag Filtering:** Filter the grid by tag, either to items that have a tag or to items missing it, useful for finding what still needs tagging.
 
 ## Requirements
 - A [Jellyfin](https://jellyfin.org/) server.

--- a/index.html
+++ b/index.html
@@ -43,6 +43,16 @@
           <option value="date-desc" selected>Date Added (Newest)</option>
           <option value="date-asc">Date Added (Oldest)</option>
         </select>
+        <div id="tag-filter-wrapper" class="tag-filter-wrapper">
+          <button id="tag-filter-toggle" type="button" class="glass-button header-button tag-filter-toggle-btn">
+            Tags <span id="tag-filter-count" class="tag-filter-count"></span>
+          </button>
+          <div id="tag-filter-panel" class="glass-panel tag-filter-panel">
+            <p class="tag-filter-hint">Click a tag to require it, click again to exclude it, once more to reset.</p>
+            <div id="tag-filter-list" class="tag-filter-list"></div>
+            <button id="tag-filter-clear" type="button" class="tag-filter-clear-btn">Clear tag filters</button>
+          </div>
+        </div>
         <button id="select-all-btn" class="glass-button header-button">
           Select All
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -243,6 +243,10 @@ select.glass-input option {
   overflow-y: auto;
   z-index: 20;
   padding: 16px;
+  /* Floats over the media grid, unlike the docked glass-panel this class
+     borrows from; the default 5% opacity left the grid's poster art
+     bleeding through and made the chips hard to read. */
+  background: rgba(13, 17, 23, 0.96);
 }
 
 .tag-filter-panel.open {

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,9 @@ select.glass-input option {
   border-radius: 16px;
   flex-wrap: wrap;
   gap: 12px;
+  /* backdrop-filter makes this its own stacking context; without a z-index
+     it paints below .main-layout and traps the tag filter dropdown under the grid. */
+  z-index: 5;
 }
 
 .header-title-group {
@@ -200,6 +203,109 @@ select.glass-input option {
   font-size: 0.9rem;
   background: rgba(255, 255, 255, 0.1);
   box-shadow: none;
+}
+
+.tag-filter-wrapper {
+  position: relative;
+}
+
+.tag-filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tag-filter-count {
+  display: none;
+  background: var(--jelly-blue);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+
+.tag-filter-count.visible {
+  display: inline-block;
+}
+
+.tag-filter-toggle-btn.active {
+  background: linear-gradient(135deg, var(--jelly-blue), var(--jelly-purple));
+}
+
+.tag-filter-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 280px;
+  max-height: 360px;
+  overflow-y: auto;
+  z-index: 20;
+  padding: 16px;
+}
+
+.tag-filter-panel.open {
+  display: block;
+}
+
+.tag-filter-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0 0 12px;
+}
+
+.tag-filter-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.tag-filter-chip {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.05);
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.tag-filter-chip:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.tag-filter-chip.include {
+  background: rgba(64, 200, 130, 0.2);
+  color: #7dfab0;
+  border-color: rgba(64, 200, 130, 0.6);
+}
+
+.tag-filter-chip.exclude {
+  background: rgba(220, 70, 70, 0.2);
+  color: #ff9d9d;
+  border-color: rgba(220, 70, 70, 0.6);
+}
+
+.tag-filter-empty-msg {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.tag-filter-clear-btn {
+  width: 100%;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--glass-border);
+  border-radius: 12px;
+  color: var(--text-main);
+  cursor: pointer;
+}
+
+.tag-filter-clear-btn:hover {
+  background: rgba(255, 255, 255, 0.14);
 }
 
 /* Footer */
@@ -677,6 +783,26 @@ select.glass-input option {
   .header-actions > * {
     flex: 1 1 calc(50% - 5px);
     min-width: 0 !important;
+  }
+
+  .tag-filter-toggle-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .tag-filter-wrapper {
+    /* .header-actions > * stretches this to 50% width via flex-basis; the
+       toggle button below it must not inherit that or it'll only cover half
+       the row while the panel (anchored to this wrapper) stays centered. */
+    flex-basis: 100% !important;
+  }
+
+  .tag-filter-panel {
+    left: 50%;
+    right: auto;
+    width: min(90vw, 320px);
+    max-height: 50vh;
+    transform: translateX(-50%);
   }
 
   #filters-toggle.active {

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,11 @@ let currentUserId = '';
 let proposedTags: string[] = [];
 let proposedGenres: string[] = [];
 
+// Tag filter: tags in `includeTagFilters` must be present on an item, tags in
+// `excludeTagFilters` must be absent. A tag can only be in one set at a time.
+let includeTagFilters = new Set<string>();
+let excludeTagFilters = new Set<string>();
+
 // Which metadata field the sidebar edits. Tags and genres share the same editor.
 type EditField = 'Tags' | 'Genres';
 let editTarget: EditField = 'Tags';
@@ -93,6 +98,11 @@ const sourceLibrarySelect = document.getElementById('source-library-select') as 
 const parentalRatingSelect = document.getElementById('parental-rating-select') as HTMLSelectElement;
 const sidebarToggle = document.getElementById('sidebar-toggle') as HTMLButtonElement;
 const sidebarClose = document.getElementById('sidebar-close') as HTMLButtonElement;
+const tagFilterToggle = document.getElementById('tag-filter-toggle') as HTMLButtonElement;
+const tagFilterPanel = document.getElementById('tag-filter-panel') as HTMLDivElement;
+const tagFilterList = document.getElementById('tag-filter-list') as HTMLDivElement;
+const tagFilterCount = document.getElementById('tag-filter-count') as HTMLSpanElement;
+const tagFilterClear = document.getElementById('tag-filter-clear') as HTMLButtonElement;
 
 function openSidebar() {
     sidebarEl.classList.add('open');
@@ -118,6 +128,85 @@ filtersToggle?.addEventListener('click', () => {
     headerActions?.classList.toggle('show');
     filtersToggle.classList.toggle('active');
 });
+
+function openTagFilterPanel() {
+    tagFilterPanel.classList.add('open');
+    tagFilterToggle.classList.add('active');
+}
+
+function closeTagFilterPanel() {
+    tagFilterPanel.classList.remove('open');
+    tagFilterToggle.classList.remove('active');
+}
+
+tagFilterToggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (tagFilterPanel.classList.contains('open')) {
+        closeTagFilterPanel();
+    } else {
+        openTagFilterPanel();
+    }
+});
+
+tagFilterPanel.addEventListener('click', (e) => e.stopPropagation());
+
+document.addEventListener('click', () => closeTagFilterPanel());
+
+tagFilterClear.addEventListener('click', () => {
+    includeTagFilters.clear();
+    excludeTagFilters.clear();
+    renderTagFilterPanel();
+    filterAndRender();
+});
+
+// Every known tag across the whole library, independent of the current
+// filters, so a tag stays choosable even while it's actively excluded.
+function getAllKnownTags(): string[] {
+    const tags = new Set<string>();
+    allItems.forEach(item => (item.Tags || []).forEach(t => tags.add(t)));
+    return Array.from(tags).sort((a, b) => a.localeCompare(b));
+}
+
+// Cycles a tag through: unfiltered -> must have -> must not have -> unfiltered.
+function cycleTagFilter(tag: string) {
+    if (includeTagFilters.has(tag)) {
+        includeTagFilters.delete(tag);
+        excludeTagFilters.add(tag);
+    } else if (excludeTagFilters.has(tag)) {
+        excludeTagFilters.delete(tag);
+    } else {
+        includeTagFilters.add(tag);
+    }
+    renderTagFilterPanel();
+    filterAndRender();
+}
+
+function renderTagFilterPanel() {
+    const knownTags = getAllKnownTags();
+    const activeCount = includeTagFilters.size + excludeTagFilters.size;
+
+    tagFilterCount.textContent = String(activeCount);
+    tagFilterCount.classList.toggle('visible', activeCount > 0);
+    tagFilterToggle.classList.toggle('active', activeCount > 0);
+
+    if (knownTags.length === 0) {
+        tagFilterList.innerHTML = `<span class="tag-filter-empty-msg">No tags in your library yet.</span>`;
+        return;
+    }
+
+    tagFilterList.innerHTML = knownTags.map(tag => {
+        const state = includeTagFilters.has(tag) ? 'include' : excludeTagFilters.has(tag) ? 'exclude' : '';
+        const prefix = state === 'include' ? '✓ ' : state === 'exclude' ? '✗ ' : '';
+        return `<span data-tag-filter="${escapeHtml(tag)}" class="tag-filter-chip ${state}">${prefix}${escapeHtml(tag)}</span>`;
+    }).join('');
+
+    tagFilterList.querySelectorAll('[data-tag-filter]').forEach(el => {
+        el.addEventListener('click', (e) => {
+            const tag = (e.currentTarget as HTMLElement).getAttribute('data-tag-filter')!;
+            cycleTagFilter(tag);
+        });
+    });
+}
 
 // 3. Core Logic
 async function init() {
@@ -195,6 +284,7 @@ async function fetchItems() {
 
         allItems = Array.from(allItemsById.values());
         renderParentalRatingFilterOptions();
+        renderTagFilterPanel();
 
         filterAndRender();
     } catch (err) {
@@ -311,14 +401,17 @@ function filterAndRender() {
     const selectedLibraryId = sourceLibrarySelect.value;
     const selectedParentalRating = parentalRatingSelect.value;
 
-    let filtered = allItems.filter(i =>
-        (selectedLibraryId === 'all' || i.SourceLibraryId === selectedLibraryId) &&
-        (selectedParentalRating === 'all' || (i.OfficialRating || '').trim() === selectedParentalRating) &&
-        (
-            (i.Name || '').toLowerCase().includes(q) ||
-            (i.Tags && i.Tags.some((t: string) => t.toLowerCase().includes(q)))
-        )
-    );
+    let filtered = allItems.filter(i => {
+        const itemTags = i.Tags || [];
+        return (selectedLibraryId === 'all' || i.SourceLibraryId === selectedLibraryId) &&
+            (selectedParentalRating === 'all' || (i.OfficialRating || '').trim() === selectedParentalRating) &&
+            (
+                (i.Name || '').toLowerCase().includes(q) ||
+                itemTags.some((t: string) => t.toLowerCase().includes(q))
+            ) &&
+            Array.from(includeTagFilters).every(t => itemTags.includes(t)) &&
+            Array.from(excludeTagFilters).every(t => !itemTags.includes(t));
+    });
 
     const sortVal = sortSelect.value;
     filtered.sort((a, b) => {


### PR DESCRIPTION
## Summary
- Adds a "Tags" dropdown to the header filter row, listing every tag present anywhere in the library.
- Clicking a tag cycles it through three states: require it (item must have the tag), exclude it (item must not have the tag), then back to unfiltered.
- The tag filter combines (AND) with the existing search box, library and parental rating filters, so it can narrow down "items missing tag X" within a specific library or search term.
- Fixes closes #22

## Design notes
- Chose a dedicated dropdown over extending the free-text search input, since substring search and structured include/exclude filtering are different operations and conflating them (e.g. `-tag` syntax) would make the existing search harder to reason about.
- Include and exclude are mutually exclusive per tag; a tag can't be in both sets at once.
- Fixed an existing stacking-context bug found while building this: `.header-panel` uses `backdrop-filter`, which creates its own stacking context that painted below `.main-content`, so any dropdown anchored in the header would render behind the media grid. Gave `.header-panel` an explicit `z-index` to fix it.

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass.
- [x] Manually exercised against a real Jellyfin library (`npm run dev`, headless Chromium): verified include/exclude/reset cycling, that include-count + exclude-count always sum to the total item count, that the tag filter combines correctly with the search box, and that clicking outside the panel closes it.
- [x] Verified the mobile collapsed-filters layout: the Tags button now spans the full row and the panel opens centered below it without overlapping the other filter controls.