### PR TITLE
fix: stop exposing the admin Jellyfin token in the client bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apk upgrade --no-cache
 # Copy built assets
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Copy nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx config template, rendered at container start (docker-entrypoint.sh)
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 
 # Copy entrypoint script
 COPY docker-entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JellyTags is a lightweight, responsive web application for managing tags within 
 - An API Token from your Jellyfin server with **Administrator** privileges (needed to fetch the admin user's library context and update items).
 
 ## Running via Docker (Recommended)
-You can easily spin up the JellyTags interface using Docker and Docker Compose. Environment variables are substituted at runtime.
+You can easily spin up the JellyTags interface using Docker and Docker Compose. `VITE_JELLYFIN_URL` and `VITE_JELLYFIN_TOKEN` are only used server-side, by nginx's reverse proxy under `/jellyfin`: the browser talks to that same-origin path and never sees the Jellyfin URL or token.
 
 ### 1. Create a `docker-compose.yml`
 Create a `docker-compose.yml` file anywhere on your server, or clone this repository and modify the existing one.
@@ -68,6 +68,7 @@ To run JellyTags locally, create a `.env` file at the root of the project:
 VITE_JELLYFIN_URL=http://localhost:8096
 VITE_JELLYFIN_TOKEN=your_admin_api_token
 ```
+These are only read by Vite's dev proxy (`server.proxy` in `vite.config.ts`), which mirrors the production nginx reverse proxy: the app itself calls the relative `/jellyfin` path and never reads either value directly.
 
 ### 4. Start the Development Server
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - "8181:80"
     environment:
+      # Used only by nginx's reverse proxy (server-side) to reach Jellyfin
+      # and inject the token; the browser never sees either value.
       - VITE_JELLYFIN_URL=http://your-jellyfin-server:8096
       - VITE_JELLYFIN_TOKEN=your-api-token # MUST HAVE ADMIN PRIVILEGES
     # Optionally mount a local env file

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
-# Replace env vars in JavaScript files
-echo "Replacing env constants in JS"
-for file in /usr/share/nginx/html/assets/*.js; do
-  if [ -f "$file" ]; then
-    sed -i "s|__JELLYFIN_URL__|${VITE_JELLYFIN_URL}|g" $file
-    sed -i "s|__JELLYFIN_TOKEN__|${VITE_JELLYFIN_TOKEN}|g" $file
-  fi
-done
+echo "Rendering Nginx config"
+envsubst '${VITE_JELLYFIN_URL} ${VITE_JELLYFIN_TOKEN}' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+
 echo "Starting Nginx"
 nginx -g 'daemon off;'

--- a/docs/issue-20-cors-proxy.md
+++ b/docs/issue-20-cors-proxy.md
@@ -1,0 +1,128 @@
+# Issue #20 — Fix CORS by proxying Jellyfin requests
+
+**Status:** Implemented
+**Issue:** https://github.com/christt105/jellytags/issues/20
+
+## Problem
+
+JellyTags is a pure browser SPA (`src/main.ts` + `@jellyfin/sdk`) that talks
+**directly from the browser to the Jellyfin server**:
+
+- `src/main.ts:18` — `jellyfin.createApi(serverUrl)` with `serverUrl = VITE_JELLYFIN_URL`.
+- Image URLs are hand-built against the same absolute host (`src/main.ts:259`, `:456`).
+
+Because the request to e.g. `https://jellyfin.domain.com/System/Info/Public`
+crosses origins, the browser issues a CORS preflight. Jellyfin does not return
+`Access-Control-Allow-Origin`, so the browser blocks the response:
+
+```
+Access to XMLHttpRequest at 'https://jellyfin.domain.com/System/Info/Public'
+from origin 'http://localhost:8181' has been blocked by CORS policy ...
+```
+
+**Fix:** stop making cross-origin requests. Route all Jellyfin traffic through a
+**same-origin reverse proxy** so the actual request to Jellyfin originates
+server-side, where CORS does not apply.
+
+## Why a Vite proxy alone is not enough
+
+The reporter suggested a Vite proxy. That fixes **dev only** (`npm run dev`).
+Production is **Nginx serving static files** (`Dockerfile` → `nginx:alpine`, no
+Node backend). So the proxy must exist in two places:
+
+| Environment        | Proxy mechanism                       |
+| ------------------ | ------------------------------------- |
+| Dev (`npm run dev`)| `server.proxy` in `vite.config.ts`    |
+| Prod (Docker)      | `proxy_pass` in a custom `nginx.conf` |
+
+Both expose Jellyfin under the same relative path (`/jellyfin`) so the client
+code is environment-agnostic.
+
+## Plan
+
+### 1. Client — use a relative base path (`src/main.ts`)
+
+- Introduce `const apiBase = '/jellyfin'` and pass it to `createApi(apiBase)`
+  instead of the absolute `serverUrl`.
+- Replace the two hand-built image URLs (`${serverUrl}/Items/...`) with
+  `${apiBase}/Items/...`.
+- `VITE_JELLYFIN_URL` is no longer read by the browser; it becomes a
+  **proxy target** consumed only by Vite (dev) and Nginx (prod).
+
+### 2. Dev proxy (`vite.config.ts`)
+
+```ts
+server: {
+  host: '0.0.0.0',
+  port: 8181,
+  proxy: {
+    '/jellyfin': {
+      target: process.env.VITE_JELLYFIN_URL,
+      changeOrigin: true,
+      rewrite: (p) => p.replace(/^\/jellyfin/, ''),
+    },
+  },
+}
+```
+
+### 3. Prod proxy (`nginx.conf.template`, new file)
+
+```nginx
+server {
+  listen 80;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location /jellyfin/ {
+    proxy_pass ${VITE_JELLYFIN_URL}/;
+    proxy_set_header Host $host;
+    # Optional security win — see below
+    # proxy_set_header X-Emby-Token ${VITE_JELLYFIN_TOKEN};
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}
+```
+
+### 4. Wire env substitution at container start (`docker-entrypoint.sh`)
+
+The Jellyfin URL is injected at container start, so the nginx config needs
+substitution too. Add an `envsubst` step alongside the existing JS `sed`:
+
+```sh
+envsubst '${VITE_JELLYFIN_URL} ${VITE_JELLYFIN_TOKEN}' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+```
+
+`Dockerfile` copies `nginx.conf.template` into `/etc/nginx/templates/`.
+(`envsubst` ships in `nginx:alpine` via the `gettext` package — confirm or
+`apk add gettext` in the runtime stage.)
+
+## Bonus: stop leaking the API token
+
+Today `VITE_JELLYFIN_TOKEN` is **baked into the client JS**
+(`docker-entrypoint.sh` seds it into the bundle), so anyone loading the page can
+read an **admin** Jellyfin token. Once the proxy exists, inject the token at the
+proxy instead (`proxy_set_header X-Emby-Token ...`) and drop it from the client
+bundle entirely. Strongly recommended, but can land as a follow-up.
+
+## Effort
+
+**~Half a day.**
+
+- Dev fix (steps 1–2): ~15 min, low risk.
+- Prod fix (steps 3–4): the real work — writing the nginx reverse proxy and
+  wiring env substitution into the existing entrypoint, then verifying in the
+  container.
+
+## Touched files
+
+- `src/main.ts` — relative API base + image URLs
+- `vite.config.ts` — dev proxy
+- `nginx.conf.template` — **new**, reverse proxy
+- `Dockerfile` — copy template, ensure `envsubst`
+- `docker-entrypoint.sh` — render template at startup
+- `docker-compose.yml` / `README.md` — note that the token is now server-side (if bonus applied)

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -11,13 +11,11 @@ server {
     gzip_types text/plain text/css text/javascript application/javascript application/json application/manifest+json image/svg+xml;
 
     # index.html, the JS/CSS bundles, sw.js and the manifest are all served
-    # under unhashed filenames (docker-entrypoint.sh sed's the Jellyfin
-    # URL/token into the bundle at container start, so Vite can't hash them),
-    # so they must revalidate on every load or a redeploy silently keeps
-    # serving the previous release out of the browser's heuristic cache.
+    # under unhashed filenames (vite.config.ts disables content hashing;
+    # enabling it is a separate follow-up), so they must revalidate on every
+    # load or a redeploy silently keeps serving the previous release out of
+    # the browser's heuristic cache.
     # no-cache (not no-store) still lets nginx answer cheap 304s via ETag.
-    # TODO: temporary until assets get content-hashed filenames, which is
-    # blocked on issue #20's reverse proxy removing the env-var sed.
     location = / {
         add_header Cache-Control "no-cache" always;
     }
@@ -42,5 +40,14 @@ server {
     # ...except the manifest itself, which can change between releases.
     location = /favicon/site.webmanifest {
         add_header Cache-Control "no-cache" always;
+    }
+
+    # Reverse proxy to Jellyfin, same-origin so the browser never makes a
+    # cross-origin request (fixes CORS, #20). The admin token is injected
+    # here, server-side, instead of being baked into the client bundle.
+    location /jellyfin/ {
+        proxy_pass ${VITE_JELLYFIN_URL}/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Emby-Token ${VITE_JELLYFIN_TOKEN};
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,12 @@ const jellyfin = new Jellyfin({
     deviceInfo: { name: 'Browser', id: 'browser-uuid' }
 });
 
-const serverUrl = import.meta.env.VITE_JELLYFIN_URL;
-const token = import.meta.env.VITE_JELLYFIN_TOKEN;
+// All Jellyfin traffic goes through this same-origin path, proxied by nginx
+// (prod) or Vite (dev). The proxy injects the admin token server-side, so
+// the client never sees it — see nginx.conf.template / vite.config.ts.
+const apiBase = '/jellyfin';
 
-const api = jellyfin.createApi(serverUrl);
-api.accessToken = token;
+const api = jellyfin.createApi(apiBase);
 
 const itemsApi = getItemsApi(api);
 const updateApi = getItemUpdateApi(api);
@@ -346,7 +347,7 @@ function renderGrid(itemsToRender: MediaItem[]) {
 
         let imgHtml = `<div class="media-no-image">No Image</div>`;
         if (item.ImageTags && item.ImageTags.Primary) {
-            const imageUrl = `${serverUrl}/Items/${item.Id}/Images/Primary?tag=${item.ImageTags.Primary}&maxWidth=400`;
+            const imageUrl = `${apiBase}/Items/${item.Id}/Images/Primary?tag=${item.ImageTags.Primary}&maxWidth=400`;
             imgHtml = `<img src="${imageUrl}" class="media-image" loading="lazy" />`;
         }
 
@@ -546,7 +547,7 @@ function renderSidebarEditor(valueCounts: Record<string, number>) {
                 ${selectedItems.map(item => {
         let thumbHtml = `<div class="selected-item-thumb-placeholder">${item.Type === 'Movie' ? 'M' : 'S'}</div>`;
         if (item.ImageTags && item.ImageTags.Primary) {
-            const thumbUrl = `${serverUrl}/Items/${item.Id}/Images/Primary?tag=${item.ImageTags.Primary}&maxWidth=80`;
+            const thumbUrl = `${apiBase}/Items/${item.Id}/Images/Primary?tag=${item.ImageTags.Primary}&maxWidth=80`;
             thumbHtml = `<img src="${thumbUrl}" class="selected-item-thumb-img" />`;
         }
         return `

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,27 +1,32 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 
-export default defineConfig(({ command }) => ({
-  server: {
-    host: '0.0.0.0',
-    port: 8181
-  },
-  // For production builds the values are baked as placeholders and swapped in at
-  // container start by docker-entrypoint.sh. In dev we let Vite load the real
-  // values from .env so `npm run dev` can actually connect to Jellyfin.
-  ...(command === 'build' ? {
-    define: {
-      'import.meta.env.VITE_JELLYFIN_URL': '"__JELLYFIN_URL__"',
-      'import.meta.env.VITE_JELLYFIN_TOKEN': '"__JELLYFIN_TOKEN__"',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    server: {
+      host: '0.0.0.0',
+      port: 8181,
+      // Mirrors the nginx reverse proxy used in production (nginx.conf.template)
+      // so the client can always call the relative /jellyfin path, in dev too.
+      proxy: {
+        '/jellyfin': {
+          target: env.VITE_JELLYFIN_URL,
+          changeOrigin: true,
+          headers: { 'X-Emby-Token': env.VITE_JELLYFIN_TOKEN },
+          rewrite: (path) => path.replace(/^\/jellyfin/, ''),
+        },
+      },
     },
-  } : {}),
-  build: {
-    modulePreload: false,
-    rollupOptions: {
-      output: {
-        entryFileNames: `assets/[name].js`,
-        chunkFileNames: `assets/[name].js`,
-        assetFileNames: `assets/[name].[ext]`
+    build: {
+      modulePreload: false,
+      rollupOptions: {
+        output: {
+          entryFileNames: `assets/[name].js`,
+          chunkFileNames: `assets/[name].js`,
+          assetFileNames: `assets/[name].[ext]`
+        }
       }
     }
   }
-}))
+})


### PR DESCRIPTION
## Problem

JellyTags is a pure browser SPA that calls Jellyfin directly from the client. `VITE_JELLYFIN_TOKEN` needs **admin** privileges (required by the README and `docker-compose.yml`), but it ends up in plain text inside the public JS: the build leaves a `__JELLYFIN_TOKEN__` placeholder (`vite.config.ts`) that `docker-entrypoint.sh` `sed`s in at container start, landing the real value in `assets/index.js`. Anyone with access to JellyTags' port can read the token from the page source and get full control of the Jellyfin server.

This is also the root cause behind issue #20 (CORS): since the app calls Jellyfin cross-origin, the browser blocks the response without `Access-Control-Allow-Origin`.

## Fix

Route all Jellyfin traffic through a same-origin reverse proxy instead of talking to Jellyfin directly from the browser:

- `src/main.ts` now points the Jellyfin SDK at a relative `/jellyfin` base path instead of the absolute server URL, and no longer sets an access token on the client.
- `nginx.conf` → `nginx.conf.template`: extends the existing file from #27 (cache headers) with a `location /jellyfin/` reverse proxy to the real Jellyfin server, injecting the token itself via `proxy_set_header X-Emby-Token`. Rendered at container start via `envsubst` (replacing the old `sed`-into-JS approach), so the token never touches the built JS.
- `vite.config.ts`: adds a matching `server.proxy` entry so `npm run dev` behaves the same way; drops the `__JELLYFIN_URL__`/`__JELLYFIN_TOKEN__` build-time placeholders since the client no longer reads either value.
- `docker-entrypoint.sh` / `Dockerfile`: replaced the JS `sed` step with rendering `nginx.conf.template` via `envsubst`.
- `docker-compose.yml` / `README.md`: clarified that `VITE_JELLYFIN_URL`/`VITE_JELLYFIN_TOKEN` are now server-side only (still required, just no longer reach the browser).
- `docs/issue-20-cors-proxy.md`: the design doc this PR implements, marked as done.

## Verification

- `npm run build`: `assets/index.js` no longer contains the Jellyfin URL or token in plain text (checked with `grep`).
- Built the real Docker image and ran it against a live Jellyfin server: `/jellyfin/System/Info/Public` and the admin-only `/jellyfin/Users` both return real data through the proxy with **zero** token sent by the client, confirming the proxy injects it server-side.
- `npm run dev`'s Vite proxy verified the same way.
- CORS is now structurally impossible for this flow (same-origin request, no preflight), not just untested.

## Notes

- Targets `fix/nginx-cache-headers` (#27) instead of `main` because it extends the `nginx.conf` added there rather than creating a parallel config. #20 should be closed once the combined work lands on `main`, not on this merge.
- Rotating the current Jellyfin token is left for a separate follow-up, since the old one may already be exposed in previously served/cached bundles.