### PR TITLE
feat: add a search box to the tag filter panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
           </button>
           <div id="tag-filter-panel" class="glass-panel tag-filter-panel">
             <p class="tag-filter-hint">Click a tag to require it, click again to exclude it, once more to reset.</p>
+            <input id="tag-filter-search" type="text" class="glass-input tag-filter-search-input" placeholder="Search tags..." autocomplete="off">
             <div id="tag-filter-list" class="tag-filter-list"></div>
             <button id="tag-filter-clear" type="button" class="tag-filter-clear-btn">Clear tag filters</button>
           </div>

--- a/index.html
+++ b/index.html
@@ -53,8 +53,9 @@
           </button>
           <div id="tag-filter-panel" class="glass-panel tag-filter-panel">
             <p class="tag-filter-hint">Click a tag to require it, click again to exclude it, once more to reset.</p>
-            <input id="tag-filter-search" type="text" class="glass-input tag-filter-search-input" placeholder="Search tags..." autocomplete="off">
+            <input id="tag-filter-search" type="text" class="glass-input tag-filter-search-input" placeholder="Search tags..." autocomplete="off" aria-label="Search tags">
             <div id="tag-filter-list" class="tag-filter-list"></div>
+            <span id="tag-filter-search-status" class="visually-hidden" aria-live="polite"></span>
             <button id="tag-filter-clear" type="button" class="tag-filter-clear-btn">Clear tag filters</button>
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -260,9 +260,25 @@ select.glass-input option {
 }
 
 .tag-filter-search-input {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   padding: 8px 12px;
   font-size: 0.8rem;
   margin-bottom: 12px;
+  background: rgba(13, 17, 23, 0.96);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .tag-filter-list {

--- a/src/index.css
+++ b/src/index.css
@@ -259,6 +259,12 @@ select.glass-input option {
   margin: 0 0 12px;
 }
 
+.tag-filter-search-input {
+  padding: 8px 12px;
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
 .tag-filter-list {
   display: flex;
   flex-wrap: wrap;

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,8 +169,6 @@ tagFilterClear.addEventListener('click', () => {
     filterAndRender();
 });
 
-// Only re-renders the tag chip list; the media grid doesn't change until a
-// chip is actually clicked.
 tagFilterSearch.addEventListener('input', () => renderTagFilterPanel());
 
 // Every known tag across the whole library, independent of the current
@@ -209,8 +207,6 @@ function renderTagFilterPanel() {
     }
 
     const searchText = tagFilterSearch.value.trim().toLowerCase();
-    // Active filters stay visible even when they don't match the search, so
-    // they can still be reset without first clearing the search box.
     const visibleTags = searchText
         ? knownTags.filter(tag => includeTagFilters.has(tag) || excludeTagFilters.has(tag) || tag.toLowerCase().includes(searchText))
         : knownTags;

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,6 +108,7 @@ const tagFilterList = document.getElementById('tag-filter-list') as HTMLDivEleme
 const tagFilterCount = document.getElementById('tag-filter-count') as HTMLSpanElement;
 const tagFilterClear = document.getElementById('tag-filter-clear') as HTMLButtonElement;
 const tagFilterSearch = document.getElementById('tag-filter-search') as HTMLInputElement;
+const tagFilterSearchStatus = document.getElementById('tag-filter-search-status') as HTMLSpanElement;
 
 function openSidebar() {
     sidebarEl.classList.add('open');
@@ -137,6 +138,7 @@ filtersToggle?.addEventListener('click', () => {
 function openTagFilterPanel() {
     tagFilterPanel.classList.add('open');
     tagFilterToggle.classList.add('active');
+    tagFilterSearch.focus();
 }
 
 function closeTagFilterPanel() {
@@ -171,12 +173,26 @@ tagFilterClear.addEventListener('click', () => {
 
 tagFilterSearch.addEventListener('input', () => renderTagFilterPanel());
 
+tagFilterList.addEventListener('click', (e) => {
+    const chip = (e.target as HTMLElement).closest('[data-tag-filter]');
+    if (!chip) return;
+    cycleTagFilter(chip.getAttribute('data-tag-filter')!);
+});
+
 // Every known tag across the whole library, independent of the current
 // filters, so a tag stays choosable even while it's actively excluded.
+let knownTagsCache: string[] = [];
+let knownTagsCacheSource: MediaItem[] | null = null;
+
 function getAllKnownTags(): string[] {
+    if (knownTagsCacheSource === allItems) {
+        return knownTagsCache;
+    }
     const tags = new Set<string>();
     allItems.forEach(item => (item.Tags || []).forEach(t => tags.add(t)));
-    return Array.from(tags).sort((a, b) => a.localeCompare(b));
+    knownTagsCache = Array.from(tags).sort((a, b) => a.localeCompare(b));
+    knownTagsCacheSource = allItems;
+    return knownTagsCache;
 }
 
 // Cycles a tag through: unfiltered -> must have -> must not have -> unfiltered.
@@ -203,31 +219,34 @@ function renderTagFilterPanel() {
 
     if (knownTags.length === 0) {
         tagFilterList.innerHTML = `<span class="tag-filter-empty-msg">No tags in your library yet.</span>`;
+        tagFilterSearchStatus.textContent = '';
         return;
     }
 
+    const isActive = (tag: string) => includeTagFilters.has(tag) || excludeTagFilters.has(tag);
     const searchText = tagFilterSearch.value.trim().toLowerCase();
-    const visibleTags = searchText
-        ? knownTags.filter(tag => includeTagFilters.has(tag) || excludeTagFilters.has(tag) || tag.toLowerCase().includes(searchText))
-        : knownTags;
+
+    // Pinned tags come first so an active include/exclude filter stays visible
+    // even when it doesn't match the current search text.
+    const pinnedTags = knownTags.filter(isActive);
+    const matchingTags = knownTags.filter(tag => !isActive(tag) && (!searchText || tag.toLowerCase().includes(searchText)));
+    const visibleTags = [...pinnedTags, ...matchingTags];
 
     if (visibleTags.length === 0) {
         tagFilterList.innerHTML = `<span class="tag-filter-empty-msg">No tags match your search.</span>`;
+        tagFilterSearchStatus.textContent = 'No tags match your search.';
         return;
     }
+
+    tagFilterSearchStatus.textContent = searchText && matchingTags.length === 0
+        ? 'No other tags match your search.'
+        : '';
 
     tagFilterList.innerHTML = visibleTags.map(tag => {
         const state = includeTagFilters.has(tag) ? 'include' : excludeTagFilters.has(tag) ? 'exclude' : '';
         const prefix = state === 'include' ? '✓ ' : state === 'exclude' ? '✗ ' : '';
         return `<span data-tag-filter="${escapeHtml(tag)}" class="tag-filter-chip ${state}">${prefix}${escapeHtml(tag)}</span>`;
     }).join('');
-
-    tagFilterList.querySelectorAll('[data-tag-filter]').forEach(el => {
-        el.addEventListener('click', (e) => {
-            const tag = (e.currentTarget as HTMLElement).getAttribute('data-tag-filter')!;
-            cycleTagFilter(tag);
-        });
-    });
 }
 
 // 3. Core Logic

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ const tagFilterPanel = document.getElementById('tag-filter-panel') as HTMLDivEle
 const tagFilterList = document.getElementById('tag-filter-list') as HTMLDivElement;
 const tagFilterCount = document.getElementById('tag-filter-count') as HTMLSpanElement;
 const tagFilterClear = document.getElementById('tag-filter-clear') as HTMLButtonElement;
+const tagFilterSearch = document.getElementById('tag-filter-search') as HTMLInputElement;
 
 function openSidebar() {
     sidebarEl.classList.add('open');
@@ -141,6 +142,10 @@ function openTagFilterPanel() {
 function closeTagFilterPanel() {
     tagFilterPanel.classList.remove('open');
     tagFilterToggle.classList.remove('active');
+    if (tagFilterSearch.value) {
+        tagFilterSearch.value = '';
+        renderTagFilterPanel();
+    }
 }
 
 tagFilterToggle.addEventListener('click', (e) => {
@@ -159,9 +164,14 @@ document.addEventListener('click', () => closeTagFilterPanel());
 tagFilterClear.addEventListener('click', () => {
     includeTagFilters.clear();
     excludeTagFilters.clear();
+    tagFilterSearch.value = '';
     renderTagFilterPanel();
     filterAndRender();
 });
+
+// Only re-renders the tag chip list; the media grid doesn't change until a
+// chip is actually clicked.
+tagFilterSearch.addEventListener('input', () => renderTagFilterPanel());
 
 // Every known tag across the whole library, independent of the current
 // filters, so a tag stays choosable even while it's actively excluded.
@@ -198,7 +208,19 @@ function renderTagFilterPanel() {
         return;
     }
 
-    tagFilterList.innerHTML = knownTags.map(tag => {
+    const searchText = tagFilterSearch.value.trim().toLowerCase();
+    // Active filters stay visible even when they don't match the search, so
+    // they can still be reset without first clearing the search box.
+    const visibleTags = searchText
+        ? knownTags.filter(tag => includeTagFilters.has(tag) || excludeTagFilters.has(tag) || tag.toLowerCase().includes(searchText))
+        : knownTags;
+
+    if (visibleTags.length === 0) {
+        tagFilterList.innerHTML = `<span class="tag-filter-empty-msg">No tags match your search.</span>`;
+        return;
+    }
+
+    tagFilterList.innerHTML = visibleTags.map(tag => {
         const state = includeTagFilters.has(tag) ? 'include' : excludeTagFilters.has(tag) ? 'exclude' : '';
         const prefix = state === 'include' ? '✓ ' : state === 'exclude' ? '✗ ' : '';
         return `<span data-tag-filter="${escapeHtml(tag)}" class="tag-filter-chip ${state}">${prefix}${escapeHtml(tag)}</span>`;


### PR DESCRIPTION
## Summary
- Adds a search input inside the tag filter panel (`#tag-filter-panel`) so tags can be filtered by substring instead of scrolling the full chip list.
- Active include/exclude chips are always kept visible and sorted first, so they stay reachable while searching even if they don't match the current search text.
- The chip list distinguishes "no tags match your search at all" from "no other tags match, but a pinned filter is still shown" via a dedicated status message.
- The search box is cleared when "Clear tag filters" is clicked or the panel is closed, and autofocuses when the panel opens.
- The search input is sticky within the scrolling panel so it stays visible while scrolling a long tag list.
- Filtering only re-renders the chip list; it doesn't touch the media grid, which still only updates when a chip is clicked.

## Implementation notes
- The known-tag list is memoized and only recomputed when the underlying item list changes, instead of rescanning every item on each keystroke.
- Chip clicks use a single delegated listener on the chip container instead of one listener per chip.
- The search input has an `aria-label`, and an `aria-live="polite"` status region announces search results for screen readers.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Manually verified against a live Jellyfin instance via the Vite dev proxy: opening the panel autofocuses the search box, typing filters chips live, an active tag stays pinned and sorted first even when the search text doesn't match it, the "no other tags match" and "no tags match your search" states both render and are announced via the aria-live region, and the underlying media grid filters correctly when a chip is clicked
