### PR TITLE
fix: authenticate via Authorization header instead of X-Emby-Token

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -86,6 +86,6 @@ server {
         # proxy.
         proxy_redirect / /jellyfin/;
         proxy_redirect ~^https?://[^/]*(/.*)?$ $scheme://$http_host/jellyfin$1;
-        proxy_set_header X-Emby-Token ${VITE_JELLYFIN_TOKEN};
+        proxy_set_header Authorization 'MediaBrowser Token="${VITE_JELLYFIN_TOKEN}"';
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,8 +18,8 @@ const jellyfin = new Jellyfin({
 const apiBase = '/jellyfin';
 
 // With no accessToken, the SDK still sends `Authorization: ... Token=""`
-// on every request; this only works because Jellyfin falls back to the
-// proxy-injected X-Emby-Token header when that Token is empty.
+// on every request; the proxy overwrites that Authorization header outright
+// with one carrying the real token, so this empty one never reaches Jellyfin.
 const api = jellyfin.createApi(apiBase);
 
 const itemsApi = getItemsApi(api);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ command, mode }) => {
         '/jellyfin': {
           target: env.VITE_JELLYFIN_URL,
           changeOrigin: true,
-          headers: { 'X-Emby-Token': env.VITE_JELLYFIN_TOKEN },
+          headers: { Authorization: `MediaBrowser Token="${env.VITE_JELLYFIN_TOKEN}"` },
           rewrite: (path) => path.replace(/^\/jellyfin/, ''),
         },
       },


### PR DESCRIPTION
## Summary

Jellyfin 12.0 stopped parsing `X-Emby-Token` (and the other legacy auth
headers `X-Emby-Authorization`/`X-MediaBrowser-Token`), since
`EnableLegacyAuthorization` now defaults to `false`. JellyTags' proxies
(nginx in prod, Vite in dev) were injecting the admin token via
`X-Emby-Token`, so on Jellyfin 12.0 every authenticated request gets
challenged and 401s, even with a freshly generated token, matching
the report in #30 (`/System/Info/Public` still returns 200 since it's
unauthenticated; `/Users` 401s).

Both proxies now overwrite the SDK's empty `Authorization` header with
one carrying the real token in the standard `MediaBrowser Token="..."`
form instead. That form isn't new in 12.0, it's the long-standing way
to authenticate with a static API key, so this doesn't need any
Jellyfin-version branching and stays compatible with pre-12.0 servers.

Fixes #30

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [ ] Manual verification against a real Jellyfin 12.0 instance (auth
      previously 401'd, should now succeed)
